### PR TITLE
Add highlights for builtin widgets

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -15,30 +15,9 @@
 
 ; Builtin widgets
 
-((symbol) @type
-  (#any-of? @type
-    "box"
-    "button"
-    "calendar"
-    "centerbox"
-    "checkbox"
-    "circular-progress"
-    "color-button"
-    "color-chooser"
-    "combo-box-text"
-    "eventbox"
-    "expander"
-    "graph"
-    "image"
-    "input"
-    "label"
-    "literal"
-    "overlay"
-    "progress"
-    "revealer"
-    "scale"
-    "scroll"
-    "transform"))
+(list .
+  ((symbol) @tag.builtin
+    (#match? @tag.builtin "^(box|button|calendar|centerbox|checkbox|circular-progress|color-button|color-chooser|combo-box-text|eventbox|expander|graph|image|input|label|literal|overlay|progress|revealer|scale|scroll|transform)$")))
 
 ; Functions
 

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -13,6 +13,33 @@
 ((symbol) @keyword
   (#any-of? @keyword "defwindow" "defwidget" "defvar" "defpoll" "deflisten" "for" "geometry" "children" "struts"))
 
+; Builtin widgets
+
+((symbol) @type
+  (#any-of? @type
+    "box"
+    "button"
+    "calendar"
+    "centerbox"
+    "checkbox"
+    "circular-progress"
+    "color-button"
+    "color-chooser"
+    "combo-box-text"
+    "eventbox"
+    "expander"
+    "graph"
+    "image"
+    "input"
+    "label"
+    "literal"
+    "overlay"
+    "progress"
+    "revealer"
+    "scale"
+    "scroll"
+    "transform"))
+
 ; Functions
 
 (function_call


### PR DESCRIPTION
I chose to highlight them as `@type` because widgets can be seen as some kind of object so I think it's the most appropriate group.