### PR TITLE
fix: broken highlight for function calls

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -5,8 +5,9 @@
 
 ; Includes
 
-((symbol) @include
-  (#match? @include "^include$"))
+(list .
+  ((symbol) @include
+    (#eq? @include "include")))
 
 ; Keywords
 
@@ -14,7 +15,7 @@
 ; https://github.com/tree-sitter/tree-sitter/pull/2107
 (list .
   ((symbol) @keyword
-	  (#match? @keyword "^(defwindow|defwidget|defvar|defpoll|deflisten|geometry|children|struts)$")))
+    (#match? @keyword "^(defwindow|defwidget|defvar|defpoll|deflisten|geometry|children|struts)$")))
 
 (loop_widget . "for" @keyword . (symbol) @variable . "in" @string . [((symbol) @variable) (_)] . (list) @string)
 

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -210,11 +210,6 @@
 
 (comment) @comment @spell
 
-; Other stuff that has not been catched by the previous queries yet
-
-(ident) @variable
-(index) @property
-
 ; Errors
 
 (ERROR) @error

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -6,7 +6,7 @@
 ; Includes
 
 ((symbol) @include
-  (#match? @include "include"))
+  (#match? @include "^include$"))
 
 ; Keywords
 
@@ -24,12 +24,9 @@
   ((symbol) @tag.builtin
     (#match? @tag.builtin "^(box|button|calendar|centerbox|checkbox|circular-progress|color-button|color-chooser|combo-box-text|eventbox|expander|graph|image|input|label|literal|overlay|progress|revealer|scale|scroll|transform)$")))
 
-; Functions
-
-(function_call
-  name: (ident) @function.call)
-
 ; Variables
+
+(ident) @variable
 
 (array
   (symbol) @variable)
@@ -102,57 +99,10 @@
 	(simplexpr
 		(ident) @field))
 
-; Operators
+; Functions
 
-[
-  "+"
-  "-"
-  "*"
-  "/"
-  "%"
-	"&&"
-  "||"
-  "=="
-  "!="
-  "=~"
-	">="
-	"<="
-  ">"
-  "<"
-	"?:"
-	"?."
-  "!"
-] @operator
-
-(ternary_expression
-  ["?" ":"] @conditional.ternary)
-
-; Properties & Fields
-
-(keyword) @property
-
-(json_access
-  (_)
-  "["
-	(simplexpr
-		(ident) @property))
-
-(json_safe_access
-  (_)
-  "?."
-  "["
-	(simplexpr
-		(ident) @property))
-
-(json_dot_access
-  (index) @property)
-
-(json_safe_dot_access
-  (index) @property)
-
-(json_object
-	(simplexpr
-		(ident) @field))
+(function_call
+  name: (ident) @function.call)
 
 ; Operators
 
@@ -173,6 +123,7 @@
   "<="
   "!"
   "?."
+  "?:"
 ] @operator
 
 (ternary_expression


### PR DESCRIPTION
I noticed that functions are successfully captured as `@function.call` but are overridden by `@variable` and the reason is line 215 of queries/highlight.scm. Moreover each variable is captured as `@variable` twice and each property is captured as `@property` twice (line 216). I tested the query file without these two lines and everything works fine, so I guess they can be safely removed, or am I missing something important?