### PR TITLE
fix: broken highlight for ternary operators

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -86,18 +86,15 @@
   "?:"
 ] @operator
 
-(ternary_expression
-  ["?" ":"] @conditional.ternary)
-
 ; Punctuation
 
-[
-  ":"
-  "."
-  ","
-] @punctuation.delimiter
-
+[":" "." ","] @punctuation.delimiter
 ["{" "}" "[" "]" "(" ")"] @punctuation.bracket
+
+; Ternary expression
+
+(ternary_expression
+  ["?" ":"] @conditional.ternary)
 
 ; Literals
 


### PR DESCRIPTION
Just a little fix, I moved the `@conditional.ternary` query after `@punctuation.delimiter` so that `:` does not get overridden.